### PR TITLE
Add support for multi-threading

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,6 +503,16 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// New threads will inherit the counter. (Default to false.)
+    ///
+    /// This can not be used if the counter belongs to a `Group`, doing so will
+    /// result in an error when the counter is built.
+    pub fn inherit(mut self, inherit: bool) -> Builder<'a> {
+        let flag = if inherit { 1 } else { 0 };
+        self.attrs.set_inherit(flag);
+        self
+    }
+
     /// Count events of the given kind. This accepts an [`Event`] value,
     /// or any type that can be converted to one, so you can pass [`Hardware`],
     /// [`Software`] and [`Cache`] values directly.


### PR DESCRIPTION
Hi, thanks for this crate, it's really helpful!

I'm interested in benchmarking multi-threaded applications and to do that I need to set the `inherit` flag so that I can measure events in new threads, I simply extended the builder and here are my changes in case anyone is interested in similar applications.
Unfortunately it seems that `inherit` doesn't play very well with groups (see the [man page](https://man7.org/linux/man-pages/man2/perf_event_open.2.html)), but I'm not sure there is anything we can do about that.