### PR TITLE
Make calls to `perf_event_open` read errors from errno

### DIFF
--- a/perf-event-open-sys/src/functions.rs
+++ b/perf-event-open-sys/src/functions.rs
@@ -21,8 +21,8 @@ use std::os::raw::{c_int, c_ulong};
 ///
 /// See the [`perf_event_open(2) man page`][man] for details.
 ///
-/// On error, this returns a negated raw OS error value. The C `errno` value is
-/// not changed.
+/// On error, this returns -1, and the C `errno` value (accessible via
+/// `std::io::Error::last_os_error`) is set to indicate the error.
 ///
 /// Note: The `attrs` argument needs to be a `*mut` because if the `size` field
 /// is too small or too large, the kernel writes the size it was expecing back


### PR DESCRIPTION
It looks like in the past this was not valid (see issue #4) but since this was last changed things seem to have changed and now the sys bindings for perf_event_open use libc::syscall which returns the error in errno.

This commit replaces the check_raw_syscall calls around perf_event_open with check_errno_syscall. This means that check_raw_syscall is no longer used so it has been deleted. I have also includes a test case to verify that the correct error code is returned in at least one case.

Fixes #18