### PR TITLE
Implement support for breakpoint events

### DIFF
--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -21,6 +21,7 @@ hooks = []
 default = ["hooks"]
 
 [dependencies]
+bitflags = "1.3"
 libc = "0.2"
 
 [dependencies.perf-event-open-sys]

--- a/perf-event/src/events.rs
+++ b/perf-event/src/events.rs
@@ -460,14 +460,14 @@ pub enum Breakpoint {
 }
 
 impl Breakpoint {
-    /// Create a breakpoint configuration to count the number of times that
-    /// the instruction at the provided address was executed.
+    /// Create a code execution breakpoint, that counts the number of
+    /// times the instruction at the provided address was executed.
     pub const fn execute(addr: u64) -> Self {
         Self::Code { addr }
     }
 
-    /// Create a breakpoint configuration to count the number of times that
-    /// we read from the provided memory location.
+    /// Create a memory read breakpoint, that counts the number of
+    /// times we read from the provided memory location.
     ///
     /// See the struct field docs for valid values of `len`.
     pub const fn read(addr: u64, len: u64) -> Self {
@@ -478,8 +478,8 @@ impl Breakpoint {
         }
     }
 
-    /// Create a breakpoint configuration to count the number of times that
-    /// we write to the provided memory location.
+    /// Create a memory write breakpoint, that counts the number of
+    /// times we write to the provided memory location.
     ///
     /// See the struct field docs for valid values of `len`.
     pub const fn write(addr: u64, len: u64) -> Self {
@@ -490,8 +490,9 @@ impl Breakpoint {
         }
     }
 
-    /// Create a breakpoint configuration to count the number of times that
-    /// we either read from or write to the provided memory location.
+    /// Create a memory access breakpoint, that counts the number of
+    /// times we either read from or write to the provided memory
+    /// location.
     ///
     /// See the struct field docs for valid values of `len`.
     pub const fn read_write(addr: u64, len: u64) -> Self {

--- a/perf-event/src/events.rs
+++ b/perf-event/src/events.rs
@@ -449,14 +449,14 @@ pub enum Breakpoint {
         /// There are a limited number of valid values for this field. Basically,
         /// the options are 1, 2, 4, and 8. Setting this field to anything else
         /// will cause counter creation to fail with an error.
-        len: u64
+        len: u64,
     },
 
     /// Code breakpoint. Triggers when the code at the address is executed.
     Code {
         /// The address that the breakpoint is monitoring.
-        addr: u64
-    }
+        addr: u64,
+    },
 }
 
 impl Breakpoint {

--- a/perf-event/src/events.rs
+++ b/perf-event/src/events.rs
@@ -50,19 +50,20 @@ pub enum Event {
 }
 
 impl Event {
-    pub(crate) fn r#type(&self) -> bindings::perf_type_id {
+    pub(crate) fn update_attrs(self, attr: &mut bindings::perf_event_attr) {
         match self {
-            Event::Hardware(_) => bindings::PERF_TYPE_HARDWARE,
-            Event::Software(_) => bindings::PERF_TYPE_SOFTWARE,
-            Event::Cache(_) => bindings::PERF_TYPE_HW_CACHE,
-        }
-    }
-
-    pub(crate) fn config(self) -> u64 {
-        match self {
-            Event::Hardware(hw) => hw as _,
-            Event::Software(sw) => sw as _,
-            Event::Cache(cache) => cache.as_config(),
+            Event::Hardware(hw) => {
+                attr.type_ = bindings::PERF_TYPE_HARDWARE;
+                attr.config = hw as _;
+            }
+            Event::Software(sw) => {
+                attr.type_ = bindings::PERF_TYPE_SOFTWARE;
+                attr.config = sw as _;
+            }
+            Event::Cache(cache) => {
+                attr.type_ = bindings::PERF_TYPE_HW_CACHE;
+                attr.config = cache.as_config();
+            }
         }
     }
 }

--- a/perf-event/src/events.rs
+++ b/perf-event/src/events.rs
@@ -398,7 +398,7 @@ bitflags! {
 /// # Ok::<(), std::io::Error>(())
 /// ```
 ///
-/// # Memory Breakpoint
+/// # Data Breakpoint
 /// We can also use a breakpoint to count the number of times that a memory
 /// location is accessed.
 /// ```
@@ -421,13 +421,14 @@ bitflags! {
 /// # Usage Notes
 /// - Some systems do not support creating read-only or write-only breakpoints.
 ///   If you are getting `EINVAL` errors while trying to build such a counter
-///   you might find that instead building a read-write counter will work.
+///   using a read-write breakpoint might work instead.
 ///
-/// - It is not valid to have a breakpoint that matches on read/write and
+/// - It is not valid to have a breakpoint that matches on both read/write and
 ///   execute accesses. Trying to do this will result in an error.
 ///
 /// - The valid values of len are quite limited. The [`perf_event_open`][man]
-///   manpage indicates that the only valid values are 1, 2, 4, and 8.
+///   manpage indicates that the only valid values for `bp_len` are 1, 2, 4,
+///   and 8.
 ///
 /// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -459,8 +459,7 @@ impl<'a> Default for Builder<'a> {
             | sys::bindings::PERF_FORMAT_TOTAL_TIME_RUNNING as u64;
 
         let kind = Event::Hardware(events::Hardware::INSTRUCTIONS);
-        attrs.type_ = kind.r#type();
-        attrs.config = kind.config();
+        kind.update_attrs(&mut attrs);
 
         Builder {
             attrs,
@@ -562,8 +561,7 @@ impl<'a> Builder<'a> {
     /// [`Cache`]: events::Cache
     pub fn kind<K: Into<Event>>(mut self, kind: K) -> Builder<'a> {
         let kind = kind.into();
-        self.attrs.type_ = kind.r#type();
-        self.attrs.config = kind.config();
+        kind.update_attrs(&mut self.attrs);
         self
     }
 

--- a/perf-event/tests/breakpoint.rs
+++ b/perf-event/tests/breakpoint.rs
@@ -1,0 +1,65 @@
+use perf_event::*;
+use std::fs::OpenOptions;
+use std::io::Write;
+
+// Need a function that will not be optimized away or inlined by the compiler.
+#[inline(never)]
+fn copy_and_fwrite(data: &[u8], file: &mut std::fs::File) -> std::io::Result<()> {
+    // This guarantees that the memory within data is read so that we can test
+    // read breakpoints.
+    let copy = data.to_vec();
+
+    file.write(&copy)?;
+    Ok(())
+}
+
+// Test a read-write data breakpoint
+#[test]
+fn data() {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open("/dev/null")
+        .expect("Unable to open /dev/null for writing");
+    let data = b"TEST DATA".to_vec();
+
+    let mut counter = Builder::new()
+        .kind(events::Breakpoint::read_write(
+            data.as_ptr() as usize as _,
+            1,
+        ))
+        .observe_self()
+        .build()
+        .expect("Unable to build performance counter");
+    counter.enable().unwrap();
+
+    for _ in 0..1000 {
+        copy_and_fwrite(&data, &mut file).unwrap();
+    }
+
+    counter.disable().unwrap();
+    assert_eq!(counter.read().unwrap(), 1000);
+}
+
+#[test]
+fn execute() {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open("/dev/null")
+        .expect("Unable to open /dev/null for writing");
+    let data = b"TEST DATA".to_vec();
+    let fnptr = copy_and_fwrite as fn(_, _) -> _;
+
+    let mut counter = Builder::new()
+        .kind(events::Breakpoint::execute(fnptr as usize as u64))
+        .observe_self()
+        .build()
+        .expect("Unable to build performance counter");
+    counter.enable().unwrap();
+
+    for _ in 0..1000 {
+        copy_and_fwrite(&data, &mut file).unwrap();
+    }
+
+    counter.disable().unwrap();
+    assert_eq!(counter.read().unwrap(), 1000);
+}

--- a/perf-event/tests/breakpoint.rs
+++ b/perf-event/tests/breakpoint.rs
@@ -1,4 +1,4 @@
-use perf_event::*;
+use perf_event::{events, Builder};
 use std::fs::OpenOptions;
 use std::io::Write;
 
@@ -13,7 +13,6 @@ fn copy_and_fwrite(data: &[u8], file: &mut std::fs::File) -> std::io::Result<()>
     Ok(())
 }
 
-// Test a read-write data breakpoint
 #[test]
 fn data() {
     let mut file = OpenOptions::new()


### PR DESCRIPTION
This PR adds support for using hardware breakpoint events. 

The detailed changes are:
- `Event::r#type()` and `Event::config()` have been replaced with a single `Event::update_attrs` method which allows the event to set whichever fields it needs to, not just `type_` and `config`.
- I've added a new `Breakpoint` event type along with appropriate docs.
- I've also added some test cases that test both read/write and execute breakpoints on the current process, I have verified that these work locally.

This also adds `bitflags` as a dependency. If you don't want that I can try to replace it with some hand-written equivalent.