### PR TITLE
Add missing software events to `events::Software` enum

### DIFF
--- a/perf-event/src/events.rs
+++ b/perf-event/src/events.rs
@@ -189,6 +189,17 @@ pub enum Software {
 
     /// Placeholder, for collecting informational sample records.
     DUMMY = bindings::PERF_COUNT_SW_DUMMY,
+
+    /// Special event type for streaming data from a eBPF program.
+    ///
+    /// See the documentation of the `bpf_perf_event_output` method in the
+    /// [`bpf-helpers(7)`] manpage for details on how to use this event type.
+    ///
+    /// [`bpf-helpers(7)`]: https://man7.org/linux/man-pages/man7/bpf-helpers.7.html
+    BPF_OUTPUT = bindings::PERF_COUNT_SW_BPF_OUTPUT,
+
+    /// Cgroup switches.
+    CGROUP_SWITCHES = bindings::PERF_COUNT_SW_CGROUP_SWITCHES,
 }
 
 impl From<Software> for Event {


### PR DESCRIPTION
This commit adds two new event types to events::Software:
- BPF_OUTPUT
- CGROUP_SWITCHES

Neither of these two enum values happen to be documented in the `perf_event_open(2)` manpage. The `BPF_OUTPUT` variant is mentioned in the `bpf-helpers(7)` manpage so I've made the documentation point there. For `CGROUP_SWITCHES` I have just taken a guess since between the manpage and `perf_event.h` header there is _no documentation for it anywhere_.

I also did a quick check to see if any other other event configs were missing new enum variants but didn't see anything missing other than what's in this PR.