### PR TITLE
default FDs to CLOEXEC, expose enable_on_exec

### DIFF
--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -488,6 +488,12 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// Exclude user code.
+    pub fn exclude_user(mut self) -> Builder<'a> {
+        self.attrs.set_exclude_user(1);
+        self
+    }
+
     /// Include hypervisor code.
     pub fn include_hv(mut self) -> Builder<'a> {
         self.attrs.set_exclude_hv(0);

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -612,6 +612,12 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// Enable on exec. If this isn't called, the Counter must be enabled by calling [`enable`].
+    pub fn enable_on_exec(mut self) -> Builder<'a> {
+        self.attrs.set_enable_on_exec(1);
+        self
+    }
+
     /// Place the counter in the given [`Group`]. Groups allow a set of counters
     /// to be enabled, disabled, or read as a single atomic operation, so that
     /// the counts can be usefully compared.
@@ -631,7 +637,9 @@ impl<'a> Builder<'a> {
     /// `Builder`.
     ///
     /// A freshly built `Counter` is disabled. To begin counting events, you
-    /// must call [`enable`] on the `Counter` or the `Group` to which it belongs.
+    /// must call [`enable`] on the `Counter` or the `Group` to which it belongs,
+    /// unless you use [`enable_on_exec`], in which case this counter will
+    /// automatically enable once its target execs.
     ///
     /// If the `Builder` requests features that the running kernel does not
     /// support, it returns `Err(e)` where `e.kind() == ErrorKind::Other` and

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -205,6 +205,7 @@ pub struct Builder<'a> {
     who: EventPid<'a>,
     cpu: Option<usize>,
     group: Option<&'a mut Group>,
+    cloexec: bool,
 }
 
 #[derive(Debug)]
@@ -470,6 +471,7 @@ impl<'a> Default for Builder<'a> {
             who: EventPid::ThisProcess,
             cpu: None,
             group: None,
+            cloexec: true,
         }
     }
 }
@@ -618,6 +620,12 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// By default, perf event FDs are open with PERF_FLAG_FD_CLOEXEC, so the FD you get back has
+    /// CLOEXEC set. Call this to not do so.
+    pub fn unset_cloexec(mut self) {
+        self.cloexec = false;
+    }
+
     /// Place the counter in the given [`Group`]. Groups allow a set of counters
     /// to be enabled, disabled, or read as a single atomic operation, so that
     /// the counts can be usefully compared.
@@ -656,7 +664,7 @@ impl<'a> Builder<'a> {
             Some(cpu) => cpu as c_int,
             None => -1,
         };
-        let (pid, flags) = self.who.as_args();
+        let (pid, mut flags) = self.who.as_args();
         let group_fd = match self.group {
             Some(ref mut g) => {
                 g.max_members += 1;
@@ -664,6 +672,10 @@ impl<'a> Builder<'a> {
             }
             None => -1,
         };
+
+        if self.cloexec {
+            flags |= perf_event_open_sys::bindings::PERF_FLAG_FD_CLOEXEC;
+        }
 
         let file = unsafe {
             File::from_raw_fd(check_errno_syscall(|| {


### PR DESCRIPTION
Hey there, thanks for this crate.

Here are  couple patches I've been using that I thought you might find useful to merge:

    default FDs to CLOEXEC
    
    Note: this is a behavior change.
    
    Currently, this crate opens FDs without CLOEXEC, which means they
    persist across exec. This is not the convention throughout the Rust
    ecosystem, which is to do the opposite:
    
    https://github.com/rust-lang/rust/issues/24237
    
    This patch sets CLOEXEC :)
    
    Note that doing that after-the-fact on the resulting FD isn't quite good
    enough: if your process is forking a lot, that's racy.

---

    expose enable-on-exec
    
    This adds support for setting `enable-on-exec`