### PR TITLE
Update perf-event-open-sys manifest to use correct repo

### DIFF
--- a/perf-event-open-sys/Cargo.toml
+++ b/perf-event-open-sys/Cargo.toml
@@ -7,7 +7,7 @@ types and constants.
 """
 license = "MIT OR Apache-2.0"
 authors = ["Jim Blandy <jimb@red-bean.com>"]
-repository = "https://github.com/jimblandy/perf-event-open-sys.git"
+repository = "https://github.com/jimblandy/perf-event/tree/master/perf-event-open-sys"
 edition = "2018"
 readme = "README.md"
 documentation = "https://docs.rs/perf-event-open-sys/"


### PR DESCRIPTION
The repository URL in the manifest points to an archived repo. It should point to this current repo.