### PR TITLE
Update Cargo.toml to point to unified repo

### DIFF
--- a/perf-event-open-sys/Cargo.toml
+++ b/perf-event-open-sys/Cargo.toml
@@ -7,7 +7,7 @@ types and constants.
 """
 license = "MIT OR Apache-2.0"
 authors = ["Jim Blandy <jimb@red-bean.com>"]
-repository = "https://github.com/jimblandy/perf-event-open-sys.git"
+repository = "https://github.com/jimblandy/perf-event.git"
 edition = "2018"
 readme = "README.md"
 documentation = "https://docs.rs/perf-event-open-sys/"


### PR DESCRIPTION
Just for consistency, tooling trips up when it cannot find commit in the referenced repo.