### PR TITLE
Fix perf-event-open-sys repo link

### DIFF
--- a/perf-event-open-sys/Cargo.toml
+++ b/perf-event-open-sys/Cargo.toml
@@ -7,7 +7,7 @@ types and constants.
 """
 license = "MIT OR Apache-2.0"
 authors = ["Jim Blandy <jimb@red-bean.com>"]
-repository = "https://github.com/jimblandy/perf-event-open-sys.git"
+repository = "https://github.com/jimblandy/perf-event.git"
 edition = "2018"
 readme = "README.md"
 documentation = "https://docs.rs/perf-event-open-sys/"


### PR DESCRIPTION
Hi! While scraping crates.io I've found `perf-event-open-sys` to be pointing at the old archived GitHub repo instead of the new one the crate is living in (this one). This PR fixes it by updating the repo link to point to this repo.