### PR TITLE
Allow direct access to unnamed union fields on `perf_event_attr`

### DIFF
--- a/perf-event-open-sys/Cargo.toml
+++ b/perf-event-open-sys/Cargo.toml
@@ -21,4 +21,3 @@ categories = [
 
 [dependencies]
 libc = "0.2"
-memoffset = "0.9.1"

--- a/perf-event-open-sys/Cargo.toml
+++ b/perf-event-open-sys/Cargo.toml
@@ -21,3 +21,4 @@ categories = [
 
 [dependencies]
 libc = "0.2"
+memoffset = "0.9.1"

--- a/perf-event-open-sys/src/attr.rs
+++ b/perf-event-open-sys/src/attr.rs
@@ -1,0 +1,132 @@
+//! This module contains a chain of deref structs which contain fields from
+//! the unnamed unions within the [`perf_event_attr`] struct. This deref chain
+//! allows users to access the relevant inline union fields directly, the same
+//! as they would in C. By extension, that allows certain changes which would
+//! be non-breaking in C but breaking changes in bindgen-generated Rust to
+//! instead be non-breaking.
+//!
+//! The way it works is that we have several structs which manually place
+//! fields at the appropriate offset. [`perf_event_attr`] derefs to one and
+//! the chain continues on from there. All derefs are done by pointer casts
+//! on `self` so the whole sequence should compile down to a no-op.
+//!
+//! Note that there is a limitation on how many deref impls rust-analyzer is
+//! willing to traverse for autocompletion. Empirically, that limit seems to
+//! be 9. Multiple fields are batched together here to ensure that the whole
+//! chain of deref impls remains visible to autocomplete.
+
+#![allow(non_camel_case_types)]
+
+use std::mem::{self, MaybeUninit};
+use std::ops::{Deref, DerefMut};
+
+use memoffset::offset_of;
+
+use crate::bindings::{self, perf_event_attr};
+
+#[repr(C)]
+pub struct AttrDeref1 {
+    _pad1: [MaybeUninit<u8>; Layout1::PAD1],
+    pub sample_period: u64,
+    _pad2: [MaybeUninit<u8>; Layout1::PAD2],
+    pub wakeup_events: u32,
+    _pad3: [MaybeUninit<u8>; Layout1::PAD3],
+    pub bp_addr: u64,
+    _pad4: [MaybeUninit<u8>; Layout1::PAD4],
+    pub bp_len: u64,
+    _pad5: [MaybeUninit<u8>; Layout1::PAD5],
+}
+
+#[repr(C)]
+pub struct AttrDeref2 {
+    _pad1: [MaybeUninit<u8>; Layout1::PAD1],
+    pub sample_freq: u64,
+    _pad2: [MaybeUninit<u8>; Layout1::PAD2],
+    pub wakeup_watermark: u32,
+    _pad3: [MaybeUninit<u8>; Layout1::PAD3],
+    pub kprobe_func: u64,
+    _pad4: [MaybeUninit<u8>; Layout1::PAD4],
+    pub kprobe_addr: u64,
+    _pad5: [MaybeUninit<u8>; Layout1::PAD5],
+}
+
+#[repr(C)]
+pub struct AttrDeref3 {
+    _pad1: [MaybeUninit<u8>; Layout2::PAD1],
+    pub uprobe_path: u64,
+    _pad2: [MaybeUninit<u8>; Layout2::PAD2],
+    pub probe_offset: u64,
+    _pad3: [MaybeUninit<u8>; Layout2::PAD3],
+}
+
+#[repr(C)]
+pub struct AttrDeref4 {
+    _pad1: [MaybeUninit<u8>; Layout2::PAD1],
+    pub config1: u64,
+    _pad2: [MaybeUninit<u8>; Layout2::PAD2],
+    pub config2: u64,
+    _pad3: [MaybeUninit<u8>; Layout2::PAD3],
+}
+
+macro_rules! deref_cast {
+    ($source:ident => $target:ident) => {
+        impl Deref for $source {
+            type Target = $target;
+
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                const _: () = {
+                    assert!(mem::size_of::<$source>() == mem::size_of::<$target>());
+                };
+
+                unsafe { &*(self as *const Self as *const Self::Target) }
+            }
+        }
+
+        impl DerefMut for $source {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                unsafe { &mut *(self as *mut Self as *mut Self::Target) }
+            }
+        }
+    };
+}
+
+deref_cast!(perf_event_attr => AttrDeref1);
+deref_cast!(AttrDeref1 => AttrDeref2);
+deref_cast!(AttrDeref2 => AttrDeref3);
+deref_cast!(AttrDeref3 => AttrDeref4);
+
+enum Offsets {}
+
+impl Offsets {
+    const OFF1: usize = offset_of!(perf_event_attr, __bindgen_anon_1);
+    const OFF2: usize = offset_of!(perf_event_attr, __bindgen_anon_2);
+    const OFF3: usize = offset_of!(perf_event_attr, __bindgen_anon_3);
+    const OFF4: usize = offset_of!(perf_event_attr, __bindgen_anon_4);
+
+    const END1: usize = Self::OFF1 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_1>();
+    const END2: usize = Self::OFF2 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_2>();
+    const END3: usize = Self::OFF3 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_3>();
+    const END4: usize = Self::OFF4 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_4>();
+}
+
+/// Layout with fields from all 4 unions
+enum Layout1 {}
+
+impl Layout1 {
+    const PAD1: usize = Offsets::OFF1;
+    const PAD2: usize = Offsets::OFF2 - Offsets::END1;
+    const PAD3: usize = Offsets::OFF3 - Offsets::END2;
+    const PAD4: usize = Offsets::OFF4 - Offsets::END3;
+    const PAD5: usize = mem::size_of::<perf_event_attr>() - Offsets::END4;
+}
+
+/// Layout with fields from only the last 2 unions
+enum Layout2 {}
+
+impl Layout2 {
+    const PAD1: usize = Offsets::OFF3;
+    const PAD2: usize = Offsets::OFF4 - Offsets::END3;
+    const PAD3: usize = mem::size_of::<perf_event_attr>() - Offsets::END4;
+}

--- a/perf-event-open-sys/src/attr.rs
+++ b/perf-event-open-sys/src/attr.rs
@@ -19,8 +19,7 @@
 
 use std::mem::{self, MaybeUninit};
 use std::ops::{Deref, DerefMut};
-
-use memoffset::offset_of;
+use std::mem::offset_of;
 
 use crate::bindings::{self, perf_event_attr};
 

--- a/perf-event-open-sys/src/attr.rs
+++ b/perf-event-open-sys/src/attr.rs
@@ -17,9 +17,9 @@
 
 #![allow(non_camel_case_types)]
 
+use std::mem::offset_of;
 use std::mem::{self, MaybeUninit};
 use std::ops::{Deref, DerefMut};
-use std::mem::offset_of;
 
 use crate::bindings::{self, perf_event_attr};
 
@@ -34,37 +34,41 @@ pub struct AttrDeref1 {
     _pad4: [MaybeUninit<u8>; Layout1::PAD4],
     pub bp_len: u64,
     _pad5: [MaybeUninit<u8>; Layout1::PAD5],
+    pub aux_action: u32,
+    _pad6: [MaybeUninit<u8>; Layout1::PAD6],
 }
 
 #[repr(C)]
 pub struct AttrDeref2 {
-    _pad1: [MaybeUninit<u8>; Layout1::PAD1],
+    _pad1: [MaybeUninit<u8>; Layout2::PAD1],
     pub sample_freq: u64,
-    _pad2: [MaybeUninit<u8>; Layout1::PAD2],
+    _pad2: [MaybeUninit<u8>; Layout2::PAD2],
     pub wakeup_watermark: u32,
-    _pad3: [MaybeUninit<u8>; Layout1::PAD3],
+    _pad3: [MaybeUninit<u8>; Layout2::PAD3],
     pub kprobe_func: u64,
-    _pad4: [MaybeUninit<u8>; Layout1::PAD4],
+    _pad4: [MaybeUninit<u8>; Layout2::PAD4],
     pub kprobe_addr: u64,
-    _pad5: [MaybeUninit<u8>; Layout1::PAD5],
+    _pad5: [MaybeUninit<u8>; Layout2::PAD5],
+    // note: there is an anonymous bitfield here, we don't conveniently expose
+    //       that yet.
 }
 
 #[repr(C)]
 pub struct AttrDeref3 {
-    _pad1: [MaybeUninit<u8>; Layout2::PAD1],
+    _pad1: [MaybeUninit<u8>; Layout3::PAD1],
     pub uprobe_path: u64,
-    _pad2: [MaybeUninit<u8>; Layout2::PAD2],
+    _pad2: [MaybeUninit<u8>; Layout3::PAD2],
     pub probe_offset: u64,
-    _pad3: [MaybeUninit<u8>; Layout2::PAD3],
+    _pad3: [MaybeUninit<u8>; Layout3::PAD3],
 }
 
 #[repr(C)]
 pub struct AttrDeref4 {
-    _pad1: [MaybeUninit<u8>; Layout2::PAD1],
+    _pad1: [MaybeUninit<u8>; Layout3::PAD1],
     pub config1: u64,
-    _pad2: [MaybeUninit<u8>; Layout2::PAD2],
+    _pad2: [MaybeUninit<u8>; Layout3::PAD2],
     pub config2: u64,
-    _pad3: [MaybeUninit<u8>; Layout2::PAD3],
+    _pad3: [MaybeUninit<u8>; Layout3::PAD3],
 }
 
 macro_rules! deref_cast {
@@ -103,14 +107,16 @@ impl Offsets {
     const OFF2: usize = offset_of!(perf_event_attr, __bindgen_anon_2);
     const OFF3: usize = offset_of!(perf_event_attr, __bindgen_anon_3);
     const OFF4: usize = offset_of!(perf_event_attr, __bindgen_anon_4);
+    const OFF5: usize = offset_of!(perf_event_attr, __bindgen_anon_5);
 
     const END1: usize = Self::OFF1 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_1>();
     const END2: usize = Self::OFF2 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_2>();
     const END3: usize = Self::OFF3 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_3>();
     const END4: usize = Self::OFF4 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_4>();
+    const END5: usize = Self::OFF5 + mem::size_of::<bindings::perf_event_attr__bindgen_ty_5>();
 }
 
-/// Layout with fields from all 4 unions
+/// Layout with fields from all 5 unions.
 enum Layout1 {}
 
 impl Layout1 {
@@ -118,13 +124,25 @@ impl Layout1 {
     const PAD2: usize = Offsets::OFF2 - Offsets::END1;
     const PAD3: usize = Offsets::OFF3 - Offsets::END2;
     const PAD4: usize = Offsets::OFF4 - Offsets::END3;
-    const PAD5: usize = mem::size_of::<perf_event_attr>() - Offsets::END4;
+    const PAD5: usize = Offsets::OFF5 - Offsets::END4;
+    const PAD6: usize = mem::size_of::<perf_event_attr>() - Offsets::END5;
 }
 
-/// Layout with fields from only the last 2 unions
+/// Layout with fields from only the first 4 unions.
 enum Layout2 {}
 
 impl Layout2 {
+    const PAD1: usize = Offsets::OFF1;
+    const PAD2: usize = Offsets::OFF2 - Offsets::END1;
+    const PAD3: usize = Offsets::OFF3 - Offsets::END2;
+    const PAD4: usize = Offsets::OFF4 - Offsets::END3;
+    const PAD5: usize = mem::size_of::<perf_event_attr>() - Offsets::END4;
+}
+
+/// Layout with fields from only the first 2 unions
+enum Layout3 {}
+
+impl Layout3 {
     const PAD1: usize = Offsets::OFF3;
     const PAD2: usize = Offsets::OFF4 - Offsets::END3;
     const PAD3: usize = mem::size_of::<perf_event_attr>() - Offsets::END4;

--- a/perf-event-open-sys/src/attr.rs
+++ b/perf-event-open-sys/src/attr.rs
@@ -147,3 +147,46 @@ impl Layout3 {
     const PAD2: usize = Offsets::OFF4 - Offsets::END3;
     const PAD3: usize = mem::size_of::<perf_event_attr>() - Offsets::END4;
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::bindings::perf_event_attr;
+
+    /// This test manually sets every known field on perf_event_attr. If it
+    /// starts erroring then that means a field has been replaced with an
+    /// inline union and the deref stack in this file needs to be updated.
+    #[test]
+    fn access_attr_fields() {
+        let mut attr = perf_event_attr::default();
+
+        attr.type_ = 0;
+        attr.size = 0;
+        attr.config = 0;
+        attr.sample_period = 0;
+        attr.sample_freq = 0;
+        attr.sample_type = 0;
+        attr.read_format = 0;
+        attr.wakeup_events = 0;
+        attr.wakeup_watermark = 0;
+        attr.bp_type = 0;
+        attr.bp_addr = 0;
+        attr.kprobe_func = 0;
+        attr.uprobe_path = 0;
+        attr.config1 = 0;
+        attr.bp_len = 0;
+        attr.kprobe_addr = 0;
+        attr.probe_offset = 0;
+        attr.config2 = 0;
+        attr.branch_sample_type = 0;
+        attr.sample_regs_user = 0;
+        attr.sample_stack_user = 0;
+        attr.clockid = 0;
+        attr.sample_regs_intr = 0;
+        attr.aux_watermark = 0;
+        attr.sample_max_stack = 0;
+        attr.aux_sample_size = 0;
+        attr.aux_action = 0;
+        attr.sig_data = 0;
+        attr.config3 = 0;
+    }
+}

--- a/perf-event-open-sys/src/lib.rs
+++ b/perf-event-open-sys/src/lib.rs
@@ -177,6 +177,12 @@
 //! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
 //! [`perf_event`]: https://crates.io/crates/perf_event
 
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "riscv64"
+))]
 mod attr;
 
 #[cfg(target_arch = "aarch64")]

--- a/perf-event-open-sys/src/lib.rs
+++ b/perf-event-open-sys/src/lib.rs
@@ -177,6 +177,8 @@
 //! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
 //! [`perf_event`]: https://crates.io/crates/perf_event
 
+mod attr;
+
 #[cfg(target_arch = "aarch64")]
 #[path = "bindings_aarch64.rs"]
 pub mod bindings;


### PR DESCRIPTION
I've pulled this out of #42. It allows users to directly access fields in the various unnamed unions within `perf_event_attr` directly, like they would in C. This has two main advantages:
1. It's a lot more convenient to just type, for example, `attr.bp_len` rather than `attr.__bindgen_anon_1.bp_len`.
2. When combined with `#[non_exhaustive]`, it makes pretty much all binding updates non-breaking changes.

The real benefit is 1, since it makes a whole bunch of code a little bit nicer. 2 is quite nice as well, but I think this is worth doing just for 1. The downside to this is that it's a giant hack, and requires some care to maintain when updates happen. I have included tests and static checks to verify that things work as expected, and in practice I haven't found it to be too much of a challenge keeping things up to date. IMO the upsides to this for users of the crate have been somewhat cursed code that is required to implement it.

I'd like to either get this merged or NACKed before I go upstreaming changes from perf-event2 itself.