### PR TITLE
Use `#[non_exhaustive]` to make the generated sys bindings more forward compatible

### DIFF
--- a/perf-event-open-sys/regenerate.sh
+++ b/perf-event-open-sys/regenerate.sh
@@ -112,6 +112,14 @@ function gen_bindings {
         --                                      \
         "${CLANG_ARGS[@]}"
 
+    # Mark all structs as #[non_exhaustive] so that future versions are less
+    # likely to require a major version bump.
+    sed -i "$bindings" -e 's/\(pub struct perf_.*\)/#[non_exhaustive]\n\1/g'
+    # new_bitfield_1 methods are not backwards compatible when new fields are
+    # added. Here we disable them. Users wanting them can set them field by
+    # field if they really need it.
+    sed -i "$bindings" -e 's/\( *\)pub \(fn new_bitfield_[0-9]*\)/\1#[allow(dead_code)]\n\1pub(crate) \2/g'
+
     cat src/bindings_header.rs      \
         "$bindings"                 \
         > "src/bindings_$arch.rs"

--- a/perf-event-open-sys/src/bindings_aarch64.rs
+++ b/perf-event-open-sys/src/bindings_aarch64.rs
@@ -490,6 +490,7 @@ pub const PERF_FORMAT_MAX: perf_event_read_format = 32;
 pub type perf_event_read_format = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_attr {
     pub type_: __u32,
     pub size: __u32,
@@ -660,6 +661,7 @@ pub union perf_event_attr__bindgen_ty_5 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_attr__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -805,7 +807,8 @@ impl perf_event_attr__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         aux_start_paused: __u32,
         aux_pause: __u32,
         aux_resume: __u32,
@@ -2163,7 +2166,8 @@ impl perf_event_attr {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         disabled: __u64,
         inherit: __u64,
         pinned: __u64,
@@ -2363,6 +2367,7 @@ impl perf_event_attr {
 }
 #[repr(C)]
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct perf_event_query_bpf {
     pub ids_len: __u32,
     pub prog_cnt: __u32,
@@ -2383,6 +2388,7 @@ pub const PERF_IOC_FLAG_GROUP: perf_event_ioc_flags = 1;
 pub type perf_event_ioc_flags = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_mmap_page {
     pub version: __u32,
     pub compat_version: __u32,
@@ -2419,6 +2425,7 @@ pub union perf_event_mmap_page__bindgen_ty_1 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -2663,7 +2670,8 @@ impl perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         cap_bit0: __u64,
         cap_bit0_is_deprecated: __u64,
         cap_user_rdpmc: __u64,
@@ -2799,6 +2807,7 @@ impl ::std::fmt::Debug for perf_event_mmap_page {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_header {
     pub type_: __u32,
     pub misc: __u16,
@@ -2817,6 +2826,7 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_ns_link_info {
     pub dev: __u64,
     pub ino: __u64,
@@ -2889,6 +2899,7 @@ pub union perf_mem_data_src {
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_mem_data_src__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -3265,7 +3276,8 @@ impl perf_mem_data_src__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         mem_op: __u64,
         mem_lvl: __u64,
         mem_snoop: __u64,
@@ -3349,6 +3361,7 @@ impl ::std::fmt::Debug for perf_mem_data_src {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_branch_entry {
     pub from: __u64,
     pub to: __u64,
@@ -3696,7 +3709,8 @@ impl perf_branch_entry {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         mispred: __u64,
         predicted: __u64,
         in_tx: __u64,
@@ -3760,6 +3774,7 @@ pub union perf_sample_weight {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_sample_weight__bindgen_ty_1 {
     pub var1_dw: __u32,
     pub var2_w: __u16,

--- a/perf-event-open-sys/src/bindings_riscv64gc.rs
+++ b/perf-event-open-sys/src/bindings_riscv64gc.rs
@@ -490,6 +490,7 @@ pub const PERF_FORMAT_MAX: perf_event_read_format = 32;
 pub type perf_event_read_format = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_attr {
     pub type_: __u32,
     pub size: __u32,
@@ -660,6 +661,7 @@ pub union perf_event_attr__bindgen_ty_5 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_attr__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -805,7 +807,8 @@ impl perf_event_attr__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         aux_start_paused: __u32,
         aux_pause: __u32,
         aux_resume: __u32,
@@ -2163,7 +2166,8 @@ impl perf_event_attr {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         disabled: __u64,
         inherit: __u64,
         pinned: __u64,
@@ -2363,6 +2367,7 @@ impl perf_event_attr {
 }
 #[repr(C)]
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct perf_event_query_bpf {
     pub ids_len: __u32,
     pub prog_cnt: __u32,
@@ -2383,6 +2388,7 @@ pub const PERF_IOC_FLAG_GROUP: perf_event_ioc_flags = 1;
 pub type perf_event_ioc_flags = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_mmap_page {
     pub version: __u32,
     pub compat_version: __u32,
@@ -2419,6 +2425,7 @@ pub union perf_event_mmap_page__bindgen_ty_1 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -2663,7 +2670,8 @@ impl perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         cap_bit0: __u64,
         cap_bit0_is_deprecated: __u64,
         cap_user_rdpmc: __u64,
@@ -2799,6 +2807,7 @@ impl ::std::fmt::Debug for perf_event_mmap_page {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_header {
     pub type_: __u32,
     pub misc: __u16,
@@ -2817,6 +2826,7 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_ns_link_info {
     pub dev: __u64,
     pub ino: __u64,
@@ -2889,6 +2899,7 @@ pub union perf_mem_data_src {
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_mem_data_src__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -3265,7 +3276,8 @@ impl perf_mem_data_src__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         mem_op: __u64,
         mem_lvl: __u64,
         mem_snoop: __u64,
@@ -3349,6 +3361,7 @@ impl ::std::fmt::Debug for perf_mem_data_src {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_branch_entry {
     pub from: __u64,
     pub to: __u64,
@@ -3696,7 +3709,8 @@ impl perf_branch_entry {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         mispred: __u64,
         predicted: __u64,
         in_tx: __u64,
@@ -3760,6 +3774,7 @@ pub union perf_sample_weight {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_sample_weight__bindgen_ty_1 {
     pub var1_dw: __u32,
     pub var2_w: __u16,

--- a/perf-event-open-sys/src/bindings_x86_64.rs
+++ b/perf-event-open-sys/src/bindings_x86_64.rs
@@ -490,6 +490,7 @@ pub const PERF_FORMAT_MAX: perf_event_read_format = 32;
 pub type perf_event_read_format = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_attr {
     pub type_: __u32,
     pub size: __u32,
@@ -660,6 +661,7 @@ pub union perf_event_attr__bindgen_ty_5 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_attr__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -805,7 +807,8 @@ impl perf_event_attr__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         aux_start_paused: __u32,
         aux_pause: __u32,
         aux_resume: __u32,
@@ -2163,7 +2166,8 @@ impl perf_event_attr {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         disabled: __u64,
         inherit: __u64,
         pinned: __u64,
@@ -2363,6 +2367,7 @@ impl perf_event_attr {
 }
 #[repr(C)]
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct perf_event_query_bpf {
     pub ids_len: __u32,
     pub prog_cnt: __u32,
@@ -2383,6 +2388,7 @@ pub const PERF_IOC_FLAG_GROUP: perf_event_ioc_flags = 1;
 pub type perf_event_ioc_flags = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_mmap_page {
     pub version: __u32,
     pub compat_version: __u32,
@@ -2419,6 +2425,7 @@ pub union perf_event_mmap_page__bindgen_ty_1 {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -2663,7 +2670,8 @@ impl perf_event_mmap_page__bindgen_ty_1__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         cap_bit0: __u64,
         cap_bit0_is_deprecated: __u64,
         cap_user_rdpmc: __u64,
@@ -2799,6 +2807,7 @@ impl ::std::fmt::Debug for perf_event_mmap_page {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_event_header {
     pub type_: __u32,
     pub misc: __u16,
@@ -2817,6 +2826,7 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_ns_link_info {
     pub dev: __u64,
     pub ino: __u64,
@@ -2889,6 +2899,7 @@ pub union perf_mem_data_src {
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_mem_data_src__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -3265,7 +3276,8 @@ impl perf_mem_data_src__bindgen_ty_1 {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         mem_op: __u64,
         mem_lvl: __u64,
         mem_snoop: __u64,
@@ -3349,6 +3361,7 @@ impl ::std::fmt::Debug for perf_mem_data_src {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_branch_entry {
     pub from: __u64,
     pub to: __u64,
@@ -3696,7 +3709,8 @@ impl perf_branch_entry {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    #[allow(dead_code)]
+    pub(crate) fn new_bitfield_1(
         mispred: __u64,
         predicted: __u64,
         in_tx: __u64,
@@ -3760,6 +3774,7 @@ pub union perf_sample_weight {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+#[non_exhaustive]
 pub struct perf_sample_weight__bindgen_ty_1 {
     pub var1_dw: __u32,
     pub var2_w: __u16,

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -446,13 +446,12 @@ impl<'a> EventPid<'a> {
 
 impl<'a> Default for Builder<'a> {
     fn default() -> Builder<'a> {
-        let mut attrs = perf_event_attr {
-            // Setting `size` accurately will not prevent the code from working
-            // on older kernels. The module comments for `perf_event_open_sys`
-            // explain why in far too much detail.
-            size: std::mem::size_of::<perf_event_attr>() as u32,
-            ..perf_event_attr::default()
-        };
+        let mut attrs = perf_event_attr::default();
+
+        // Setting `size` accurately will not prevent the code from working
+        // on older kernels. The module comments for `perf_event_open_sys`
+        // explain why in far too much detail.
+        attrs.size = std::mem::size_of::<perf_event_attr>() as u32;
 
         attrs.set_disabled(1);
         attrs.set_exclude_kernel(1); // don't count time in kernel
@@ -818,12 +817,10 @@ impl Group {
     #[allow(unused_parens)]
     pub fn new() -> io::Result<Group> {
         // Open a placeholder perf counter that we can add other events to.
-        let mut attrs = perf_event_attr {
-            size: std::mem::size_of::<perf_event_attr>() as u32,
-            type_: sys::bindings::PERF_TYPE_SOFTWARE,
-            config: sys::bindings::PERF_COUNT_SW_DUMMY as u64,
-            ..perf_event_attr::default()
-        };
+        let mut attrs = perf_event_attr::default();
+        attrs.size = std::mem::size_of::<perf_event_attr>() as u32;
+        attrs.type_ = sys::bindings::PERF_TYPE_SOFTWARE;
+        attrs.config = sys::bindings::PERF_COUNT_SW_DUMMY as u64;
 
         attrs.set_disabled(1);
         attrs.set_exclude_kernel(1);


### PR DESCRIPTION
There are a bunch of changes that are not breaking in C but are breaking in rust. This is inconvenient both for us and for users, since we end up needing to make frequent breaking changes of `perf-event-open-sys`. This carries on throughout the whole ecosystem and leads to breaking changes for any crate that publicly re-exports types from `perf-event-open-sys`. This will notably include `perf-event`, once I get around to upstreaming some of the various changes made in `perf-event2`.

By making a few structs `#[non_exhaustive]` we can make it so that most future updates that the kernel is likely to make are not breaking changes on the rust side. This needs to be combined with #48 in order to really avoid having breaking changes.

The main trade-off, of course, is that you can no longer do `perf_event_attr { type_: blah, ...Default::default() }`. This is a real cost, but I think the benefits of avoid breaking changes are worth it here.

WRT `const`, you already can't set any of the bitflags on `perf_event_attr` in a const context. However, you can still create a zeroed  `perf_event_attr` in a const context by using `std::mem::zeroed`, like this:
```rs
const ATTR: perf_event_attr = {
  let mut attr: perf_event_attr = unsafe { std::mem::zeroed() };
  attr.size = 77;
  attr.type_ = blah;
  ...
  attr
};
```
A quick search on sourcegraph hasn't found anyone actually doing this, so I'm not sure this is much of concern for existing users.