### PR TITLE
Upstream (almost) all builder methods from `perf-event2`

### DIFF
--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -21,7 +21,7 @@ hooks = []
 default = ["hooks"]
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.9.0"
 libc = "0.2"
 
 [dependencies.perf-event-open-sys]

--- a/perf-event/src/builder.rs
+++ b/perf-event/src/builder.rs
@@ -10,9 +10,13 @@ use sys::bindings::perf_event_attr;
 use crate::check_errno_syscall;
 use crate::events;
 use crate::events::Event;
+use crate::flags::ReadFormat;
 use crate::sys;
+use crate::Clock;
 use crate::Counter;
 use crate::Group;
+use crate::SampleBranchFlag;
+use crate::SampleSkid;
 
 /// A builder for [`Counter`]s.
 ///
@@ -105,10 +109,47 @@ impl<'a> Default for Builder<'a> {
     }
 }
 
+// Methods that actually do work on the builder and aren't just setting
+// config values.
 impl<'a> Builder<'a> {
     /// Return a new `Builder`, with all parameters set to their defaults.
     pub fn new() -> Builder<'a> {
         Builder::default()
+    }
+
+    /// Count events of the given kind. This accepts an [`Event`] value,
+    /// or any type that can be converted to one, so you can pass [`Hardware`],
+    /// [`Software`] and [`Cache`] values directly.
+    ///
+    /// The default is to count retired instructions, or
+    /// `Hardware::INSTRUCTIONS` events.
+    ///
+    /// For example, to count level 1 data cache references and misses, pass the
+    /// appropriate `events::Cache` values:
+    ///
+    ///     # fn main() -> std::io::Result<()> {
+    ///     use perf_event::{Builder, Group};
+    ///     use perf_event::events::{Cache, CacheOp, CacheResult, WhichCache};
+    ///
+    ///     const ACCESS: Cache = Cache {
+    ///         which: WhichCache::L1D,
+    ///         operation: CacheOp::READ,
+    ///         result: CacheResult::ACCESS,
+    ///     };
+    ///     const MISS: Cache = Cache { result: CacheResult::MISS, ..ACCESS };
+    ///
+    ///     let mut group = Group::new()?;
+    ///     let access_counter = Builder::new().group(&mut group).kind(ACCESS).build()?;
+    ///     let miss_counter = Builder::new().group(&mut group).kind(MISS).build()?;
+    ///     # Ok(()) }
+    ///
+    /// [`Hardware`]: events::Hardware
+    /// [`Software`]: events::Software
+    /// [`Cache`]: events::Cache
+    pub fn kind<K: Into<Event>>(mut self, kind: K) -> Builder<'a> {
+        let kind = kind.into();
+        kind.update_attrs(&mut self.attrs);
+        self
     }
 
     /// Construct a [`Counter`] according to the specifications made on this
@@ -166,18 +207,6 @@ impl<'a> Builder<'a> {
     /// Directly access the [`perf_event_attr`] within this builder.
     pub fn attrs_mut(&mut self) -> &mut perf_event_attr {
         &mut self.attrs
-    }
-
-    /// Include kernel code.
-    pub fn include_kernel(mut self) -> Builder<'a> {
-        self.attrs.set_exclude_kernel(0);
-        self
-    }
-
-    /// Include hypervisor code.
-    pub fn include_hv(mut self) -> Builder<'a> {
-        self.attrs.set_exclude_hv(0);
-        self
     }
 
     /// Observe the calling process. (This is the default.)
@@ -248,58 +277,6 @@ impl<'a> Builder<'a> {
         self
     }
 
-    /// Set whether this counter is inherited by new threads.
-    ///
-    /// When this flag is set, this counter observes activity in new threads
-    /// created by any thread already being observed.
-    ///
-    /// By default, the flag is unset: counters are not inherited, and observe
-    /// only the threads specified when they are created.
-    ///
-    /// This flag cannot be set if the counter belongs to a `Group`. Doing so
-    /// will result in an error when the counter is built. This is a kernel
-    /// limitation.
-    pub fn inherit(mut self, inherit: bool) -> Builder<'a> {
-        let flag = if inherit { 1 } else { 0 };
-        self.attrs.set_inherit(flag);
-        self
-    }
-
-    /// Count events of the given kind. This accepts an [`Event`] value,
-    /// or any type that can be converted to one, so you can pass [`Hardware`],
-    /// [`Software`] and [`Cache`] values directly.
-    ///
-    /// The default is to count retired instructions, or
-    /// `Hardware::INSTRUCTIONS` events.
-    ///
-    /// For example, to count level 1 data cache references and misses, pass the
-    /// appropriate `events::Cache` values:
-    ///
-    ///     # fn main() -> std::io::Result<()> {
-    ///     use perf_event::{Builder, Group};
-    ///     use perf_event::events::{Cache, CacheOp, CacheResult, WhichCache};
-    ///
-    ///     const ACCESS: Cache = Cache {
-    ///         which: WhichCache::L1D,
-    ///         operation: CacheOp::READ,
-    ///         result: CacheResult::ACCESS,
-    ///     };
-    ///     const MISS: Cache = Cache { result: CacheResult::MISS, ..ACCESS };
-    ///
-    ///     let mut group = Group::new()?;
-    ///     let access_counter = Builder::new().group(&mut group).kind(ACCESS).build()?;
-    ///     let miss_counter = Builder::new().group(&mut group).kind(MISS).build()?;
-    ///     # Ok(()) }
-    ///
-    /// [`Hardware`]: events::Hardware
-    /// [`Software`]: events::Software
-    /// [`Cache`]: events::Cache
-    pub fn kind<K: Into<Event>>(mut self, kind: K) -> Builder<'a> {
-        let kind = kind.into();
-        kind.update_attrs(&mut self.attrs);
-        self
-    }
-
     /// Place the counter in the given [`Group`]. Groups allow a set of counters
     /// to be enabled, disabled, or read as a single atomic operation, so that
     /// the counts can be usefully compared.
@@ -312,6 +289,532 @@ impl<'a> Builder<'a> {
         // set to zero."
         self.attrs.set_disabled(0);
 
+        self
+    }
+
+    /// Set the fields to include when reading from the counter.
+    ///
+    /// Note that this method is _not_ additive, unlike [`sample`].
+    ///
+    /// The implementation of this library will silently mask out certain flags
+    /// if they would be invalid. For example, we will not allow you to set
+    /// [`ReadFormat::GROUP`] when building a single counter.
+    ///
+    /// [`sample`]: Builder::sample
+    pub fn read_format(&mut self, mut read_format: ReadFormat) -> &mut Self {
+        if read_format.contains(ReadFormat::GROUP) {
+            read_format |= ReadFormat::ID;
+        }
+
+        self.attrs.read_format = read_format.bits();
+        self
+    }
+}
+
+// Section for methods which directly modify attrs. These should correspond
+// roughly 1-to-1 with the entries as documented in the manpage.
+impl<'a> Builder<'a> {
+    /// Whether this counter should start off enabled.
+    ///
+    /// When this is set, the counter will immediately start being recorded as
+    /// soon as it is created.
+    ///
+    /// By default, this is false.
+    pub fn enabled(&mut self, enabled: bool) -> &mut Self {
+        self.attrs.set_disabled((!enabled).into());
+        self
+    }
+
+    /// Set whether this counter is inherited by new threads.
+    ///
+    /// When this flag is set, this counter observes activity in new threads
+    /// created by any thread already being observed.
+    ///
+    /// By default, the flag is unset: counters are not inherited, and observe
+    /// only the threads specified when they are created.
+    ///
+    /// This flag cannot be set if the counter belongs to a `Group`. Doing so
+    /// will result in an error when the counter is built. This is a kernel
+    /// limitation.
+    pub fn inherit(&mut self, inherit: bool) -> &mut Self {
+        self.attrs.set_inherit(inherit.into());
+        self
+    }
+
+    /// Set whether the counter is pinned to the PMU.
+    ///
+    /// If this flag is set, the kernel will attempt to keep the counter on
+    /// always on the CPU if at all possible. If it fails to do so, the counter
+    /// will enter an error state where reading it will always return EOF. For
+    /// this crate, that would result in [`Counter::read`] returning an error
+    /// with kind [`ErrorKind::UnexpectedEof`].
+    ///
+    /// This option only applies to hardware counters and group leaders. At
+    /// this time this crate provides no way to configure group leaders so this
+    /// option will only work when the resulting counter is not in a group.
+    ///
+    /// This is false by default.
+    ///
+    /// [`ErrorKind::UnexpectedEof`]: std::io::ErrorKind::UnexpectedEof
+    pub fn pinned(&mut self, pinned: bool) -> &mut Self {
+        self.attrs.set_pinned(pinned.into());
+        self
+    }
+
+    /// Controls whether the counter or group can be scheduled onto a CPU
+    /// alongside other counters or groups.
+    ///
+    /// This is false by default.
+    pub fn exclusive(&mut self, exclusive: bool) -> &mut Self {
+        self.attrs.set_exclusive(exclusive.into());
+        self
+    }
+
+    /// Whether we should exclude events that occur in user space.
+    ///
+    /// This is false by default.
+    pub fn exclude_user(&mut self, exclude_user: bool) -> &mut Self {
+        self.attrs.set_exclude_user(exclude_user.into());
+        self
+    }
+
+    /// Whether we should exclude events that occur in kernel space.
+    ///
+    /// Note that setting this to false may result in permission errors if
+    /// the current `perf_event_paranoid` value is greater than 1.
+    ///
+    /// This is true by default.
+    pub fn exclude_kernel(&mut self, exclude_kernel: bool) -> &mut Self {
+        self.attrs.set_exclude_kernel(exclude_kernel.into());
+        self
+    }
+
+    /// Include kernel code.
+    ///
+    /// See [`exclude_kernel`](Builder::exclude_kernel).
+    pub fn include_kernel(&mut self) -> &mut Self {
+        self.exclude_kernel(false)
+    }
+
+    /// Whether we should exclude events that happen in the hypervisor.
+    ///
+    /// This is not supported on all architectures as it required built-in
+    /// support within the CPU itself.
+    ///
+    /// Note that setting this to false may result in permission errors if
+    /// the current `perf_event_paranoid` value is greater than 1.
+    ///
+    /// This is true by default
+    pub fn exclude_hv(&mut self, exclude_hv: bool) -> &mut Self {
+        self.attrs.set_exclude_hv(exclude_hv.into());
+        self
+    }
+
+    /// Include hypervisor code.
+    ///
+    /// See [`exclude_hv`](Builder::exclude_hv).
+    pub fn include_hv(&mut self) -> &mut Self {
+        self.exclude_hv(false)
+    }
+
+    /// Whether to exclude events that occur when running the idle task.
+    ///
+    /// Note that this only has an effect for software events.
+    pub fn exclude_idle(&mut self, exclude_idle: bool) -> &mut Self {
+        self.attrs.set_exclude_idle(exclude_idle.into());
+        self
+    }
+
+    /// Enable the generation of MMAP records for executable memory maps.
+    ///
+    /// MMAP records are emitted when the process/thread that is being
+    /// observed creates a new executable memory mapping.
+    pub fn mmap(&mut self, mmap: bool) -> &mut Self {
+        self.attrs.set_mmap(mmap.into());
+        self
+    }
+
+    /// Enable the tracking of process command name changes.
+    ///
+    /// This can happen when a process calls `execve(2)`, `prctl(PR_SET_NAME)`,
+    /// or writes to `/proc/self/comm`.
+    ///
+    /// If you also set the [`comm_exec`](Builder::comm_exec) flag, then the
+    /// kernel will indicate which of these process name changes were due to
+    /// calls to `execve(2)`.
+    pub fn comm(&mut self, comm: bool) -> &mut Self {
+        self.attrs.set_comm(comm.into());
+        self
+    }
+
+    /// Set the period at which the kernel will generate sample events.
+    ///
+    /// As an example, if the event is `Hardware::INSTRUCTIONS` and `period`
+    /// is 100_000 then every 100_000 instructions the kernel will generate an
+    /// event.
+    ///
+    /// Note that the actual precision at which the sample corresponds to the
+    /// instant and location at which Nth event occurred is controlled by the
+    /// [`precise_ip`] option.
+    ///
+    /// This setting is mutually exclusive with [`sample_frequency`].
+    ///
+    /// [`precise_ip`]: Builder::precise_ip
+    /// [`sample_frequency`]: Builder::sample_frequency
+    pub fn sample_period(&mut self, period: u64) -> &mut Self {
+        self.attrs.set_freq(0);
+        self.attrs.sample_period = period;
+        self
+    }
+
+    /// Set the frequency at which the kernel will generate sample events
+    /// (in Hz).
+    ///
+    /// Note that this is not guaranteed to be exact. The kernel will adjust
+    /// the period to attempt to keep the desired frequency but the rate at
+    /// which events occur varies drastically then samples may not occur at
+    /// the specified frequency.
+    ///
+    /// The amount to which samples correspond to the instant and location at
+    /// which an event occurred is controlled by the [`precise_ip`] option.
+    ///
+    /// This setting is mutually exclusive with [`sample_period`].
+    ///
+    /// [`precise_ip`]: Builder::precise_ip
+    /// [`sample_period`]: Builder::sample_period
+    pub fn sample_frequency(&mut self, frequency: u64) -> &mut Self {
+        self.attrs.set_freq(1);
+        self.attrs.sample_freq = frequency;
+        self
+    }
+
+    /// Save event counts on context switch for inherited tasks.
+    ///
+    /// This option is only meaningful if [`inherit`] is also enabled.
+    ///
+    /// [`inherit`]: Builder::inherit
+    pub fn inherit_stat(&mut self, inherit_stat: bool) -> &mut Self {
+        self.attrs.set_inherit_stat(inherit_stat.into());
+        self
+    }
+
+    /// Enable the counter automatically after a call to `execve(2)`.
+    pub fn enable_on_exec(&mut self, enable_on_exec: bool) -> &mut Self {
+        self.attrs.set_enable_on_exec(enable_on_exec.into());
+        self
+    }
+
+    /// If set, then the kernel will generate fork and exit records.
+    pub fn task(&mut self, task: bool) -> &mut Self {
+        self.attrs.set_task(task.into());
+        self
+    }
+
+    /// Set how many bytes will be written before the kernel sends an overflow
+    /// notification.
+    ///
+    /// This controls how much data will be emitted before
+    /// [`Sampler::next_blocking`] will wake up once blocked.
+    ///
+    /// This setting is mutually exclusive with [`wakeup_events`].
+    ///
+    /// [`wakeup_events`]: Self::wakeup_events
+    /// [`Sampler::next_blocking`]: crate::Sampler::next_blocking
+    pub fn wakeup_watermark(&mut self, watermark: usize) -> &mut Self {
+        self.attrs.set_watermark(1);
+        self.attrs.wakeup_watermark = watermark as _;
+        self
+    }
+
+    /// Set how many samples will be written before the kernel sends an
+    /// overflow notification.
+    ///
+    /// This controls how much data will be emitted before
+    /// [`Sampler::next_blocking`] will wake up once blocked. Note that only
+    /// sample records (`PERF_RECORD_SAMPLE`) count towards the event count.
+    ///
+    /// Some caveats apply, see the [manpage] for the full documentation.
+    ///
+    /// This method is mutually exclusive with [`wakeup_watermark`].
+    ///
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
+    /// [`wakeup_watermark`]: Builder::wakeup_watermark
+    /// [`Sampler::next_blocking`]: crate::Sampler::next_blocking
+    pub fn wakeup_events(&mut self, events: usize) -> &mut Self {
+        self.attrs.set_watermark(0);
+        self.attrs.wakeup_events = events as _;
+        self
+    }
+
+    /// Control how much skid is permitted when recording events.
+    ///
+    /// Skid is the number of instructions that occur between an event occuring
+    /// and a sample being gathered by the kernel. Less skid is better but
+    /// there are hardware limitations around how small the skid can be.
+    ///
+    /// Also see [`SampleSkid`].
+    pub fn precise_ip(&mut self, skid: SampleSkid) -> &mut Self {
+        self.attrs.set_precise_ip(skid as _);
+        self
+    }
+
+    /// Enable the generation of MMAP records for non-executable memory maps.
+    ///
+    /// This is the data counterpart of [`mmap`](Builder::mmap).
+    pub fn mmap_data(&mut self, mmap_data: bool) -> &mut Self {
+        self.attrs.set_mmap_data(mmap_data.into());
+        self
+    }
+
+    /// If enabled, then a subset of the sample fields will additionally be
+    /// included in most non-`PERF_RECORD_SAMPLE` samples.
+    ///
+    /// See the [manpage] for the exact fields that are included and which
+    /// records include the trailer.
+    ///
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
+    pub fn sample_id_all(&mut self, sample_id_all: bool) -> &mut Self {
+        self.attrs.set_sample_id_all(sample_id_all.into());
+        self
+    }
+
+    /// Only collect measurements for events occurring inside a VM instance.
+    ///
+    /// This is only meaningful when profiling from outside the VM instance.
+    ///
+    /// See the [manpage] for more documentation.
+    ///
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
+    pub fn exclude_host(&mut self, exclude_host: bool) -> &mut Self {
+        self.attrs.set_exclude_host(exclude_host.into());
+        self
+    }
+
+    /// Don't collect measurements for events occurring inside a VM instance.
+    ///
+    /// This is only meaningful when profiling from outside the VM instance.
+    ///
+    /// See the [manpage] for more documentation.
+    ///
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
+    pub fn exclude_guest(&mut self, exclude_guest: bool) -> &mut Self {
+        self.attrs.set_exclude_guest(exclude_guest.into());
+        self
+    }
+
+    /// Do not include stack frames in the kernel when gathering callchains as
+    /// a part of recording a sample.
+    pub fn exclude_callchain_kernel(&mut self, exclude_kernel: bool) -> &mut Self {
+        self.attrs
+            .set_exclude_callchain_kernel(exclude_kernel.into());
+        self
+    }
+
+    /// Do not include stack frames from userspace when gathering a callchain
+    /// as a part of recording a sample.
+    pub fn exclude_callchain_user(&mut self, exclude_user: bool) -> &mut Self {
+        self.attrs.set_exclude_callchain_user(exclude_user.into());
+        self
+    }
+
+    /// Generate an extended executable mmap record.
+    ///
+    /// This record has enough info to uniquely identify which instance of a
+    /// shared map it corresponds to. Note that you also need to set the `mmap`
+    /// option for this to work.
+    pub fn mmap2(&mut self, mmap2: bool) -> &mut Self {
+        self.attrs.set_mmap2(mmap2.into());
+        self
+    }
+
+    /// Check whether the kernel will annotate COMM records with the COMM_EXEC
+    /// bit when they occur due to an `execve(2)` call.
+    ///
+    /// This option doesn't actually change the behaviour of the kernel.
+    /// Instead, it is useful for feature detection.
+    pub fn comm_exec(&mut self, comm_exec: bool) -> &mut Self {
+        self.attrs.set_comm_exec(comm_exec.into());
+        self
+    }
+
+    /// Select which linux clock to use for timestamps.
+    ///
+    /// If `clockid` is `None` then the kernel will use an internal timer. This
+    /// timer may not be any of the options for clockid.
+    ///
+    /// See [`Clock`] and the [`clock_getttime(2)`][0] manpage for
+    /// documentation on what the different clock values mean.
+    ///
+    /// [0]: https://www.mankier.com/2/clock_gettime
+    pub fn clockid(&mut self, clockid: impl Into<Option<Clock>>) -> &mut Self {
+        let clockid = clockid.into();
+        self.attrs.set_use_clockid(clockid.is_some().into());
+        self.attrs.clockid = clockid.map(Clock::into_raw).unwrap_or(0);
+        self
+    }
+
+    /// Generate `SWITCH` records when a context switch occurs.
+    ///
+    /// Also enables the generation of `SWITCH_CPU_WIDE` records if profiling
+    /// in cpu-wide mode.
+    pub fn context_switch(&mut self, context_switch: bool) -> &mut Self {
+        self.attrs.set_context_switch(context_switch.into());
+        self
+    }
+
+    /// Generate `NAMESPACES` records when a task enters a new namespace.
+    pub fn namespaces(&mut self, namespaces: bool) -> &mut Self {
+        self.attrs.set_namespaces(namespaces.into());
+        self
+    }
+
+    /// Generate `KSYMBOL` records when kernel symbols are registered or
+    /// unregistered.
+    pub fn ksymbol(&mut self, ksymbol: bool) -> &mut Self {
+        self.attrs.set_ksymbol(ksymbol.into());
+        self
+    }
+
+    /// Generate `BPF_EVENT` records when eBPF programs are loaded or unloaded.
+    pub fn bpf_event(&mut self, bpf_event: bool) -> &mut Self {
+        self.attrs.set_bpf_event(bpf_event.into());
+        self
+    }
+
+    /// Output data for non-aux events to the aux buffer, if supported by the
+    /// hardware.
+    pub fn aux_output(&mut self, aux_output: bool) -> &mut Self {
+        self.attrs.set_aux_output(aux_output.into());
+        self
+    }
+
+    /// Generate `CGROUP` records when a new cgroup is created.
+    pub fn cgroup(&mut self, cgroup: bool) -> &mut Self {
+        self.attrs.set_cgroup(cgroup.into());
+        self
+    }
+
+    /// Generate `TEXT_POKE` records when the kernel text (i.e. code) is
+    /// modified.
+    pub fn text_poke(&mut self, text_poke: bool) -> &mut Self {
+        self.attrs.set_text_poke(text_poke.into());
+        self
+    }
+
+    /// Whether to include the build id in `MMAP2` events.
+    pub fn build_id(&mut self, build_id: bool) -> &mut Self {
+        self.attrs.set_build_id(build_id.into());
+        self
+    }
+
+    /// Only inherit the counter to new threads in the same process, not to
+    /// other processes.
+    pub fn inherit_thread(&mut self, inherit_thread: bool) -> &mut Self {
+        self.attrs.set_inherit_thread(inherit_thread.into());
+        self
+    }
+
+    /// Disable this counter when it successfully calls `execve(2)`.
+    pub fn remove_on_exec(&mut self, remove_on_exec: bool) -> &mut Self {
+        self.attrs.set_remove_on_exec(remove_on_exec.into());
+        self
+    }
+
+    /// Synchronously send `SIGTRAP` to the process that created the counter
+    /// when the sampled events overflow.
+    pub fn sigtrap(&mut self, sigtrap: bool) -> &mut Self {
+        self.attrs.set_sigtrap(sigtrap.into());
+        self
+    }
+
+    /// Copy data to the user's signal handler (via `si_perf` in `siginfo_t`).
+    ///
+    /// This can be used to figure out which event caused the signal to be sent.
+    /// It does nothing unless [`sigtrap`](Self::sigtrap) is also set to `true`.
+    pub fn sig_data(&mut self, sig_data: u64) -> &mut Self {
+        self.attrs.sig_data = sig_data;
+        self
+    }
+
+    /// Specify which branches to include in the branch record.
+    ///
+    /// This does nothing unless [`SampleFlag::BRANCH_STACK`] is specified in
+    /// the sample flags.
+    pub fn branch_sample_type(&mut self, flags: SampleBranchFlag) -> &mut Self {
+        self.attrs.branch_sample_type = flags.bits();
+        self
+    }
+
+    /// Specify which CPU registers to dump in a sample.
+    ///
+    /// This does nothing unless [`SampleFlag::REGS_USER`] is part of the
+    /// specified [`sample`](Builder::sample) flags.
+    ///
+    /// The actual layout of the register mask is architecture specific.
+    /// You will generally want the `PERF_REG_<arch>` constants in
+    /// [`perf_event_open_sys`]. (e.g. `PERF_REG_X86_SP`).
+    pub fn sample_regs_user(&mut self, regs: u64) -> &mut Self {
+        self.attrs.sample_regs_user = regs;
+        self
+    }
+
+    /// Specify which CPU registers to dump in a sample.
+    ///
+    /// This does nothing unless [`SampleFlag::REGS_INTR`] is part of the
+    /// specified [`sample`](Builder::sample) flags.
+    ///
+    /// The actual layout of the register mask is architecture specific.
+    /// You will generally want the `PERF_REG_<arch>` constants in
+    /// [`perf_event_open_sys`]. (e.g. `PERF_REG_X86_SP`).
+    pub fn sample_regs_intr(&mut self, regs: u64) -> &mut Self {
+        self.attrs.sample_regs_user = regs;
+        self
+    }
+
+    /// Specify the maximum size of the user stack to dump.
+    ///
+    /// This option does nothing unless [`SampleFlag::STACK_USER`] is set in the
+    /// sample flags.
+    ///
+    /// Note that the size of the array allocated within the sample record will
+    /// always be exactly this size, even if the actual collected stack data is
+    /// much smaller. The allocated sample buffer (when constructing a
+    /// [`Sampler`]) will need to be large enough to accommodate the chosen
+    /// stack size or else samples will be lost.
+    ///
+    /// [`Sampler`]: crate::Sampler
+    pub fn sample_stack_user(&mut self, stack: u32) -> &mut Self {
+        self.attrs.sample_stack_user = stack;
+        self
+    }
+
+    /// Specify the maximum number of stack frames to include when unwinding the
+    /// user stack.
+    ///
+    /// This does nothing unless [`SampleFlag::CALLCHAIN`] is set in the sample
+    /// flags.
+    ///
+    /// Note that the kernel has a user configurable limit specified at
+    /// `/proc/sys/kernel/perf_event_max_stack`. Setting `sample_max_stack` to
+    /// larger than that limit will result in an `EOVERFLOW` error when building
+    /// the counter.
+    pub fn sample_max_stack(&mut self, max_stack: u16) -> &mut Self {
+        self.attrs.sample_max_stack = max_stack;
+        self
+    }
+
+    /// Specify how much data is required before the kernel emits an AUX record.
+    pub fn aux_watermark(&mut self, watermark: u32) -> &mut Self {
+        self.attrs.aux_watermark = watermark;
+        self
+    }
+
+    /// Specify the desired size of AUX data.
+    ///
+    /// This does nothing unless [`SampleFlag::AUX`] is set in the sample flags.
+    /// Note that the emitted aux data can be smaller than the requested size.
+    pub fn aux_sample_size(&mut self, sample_size: u32) -> &mut Self {
+        self.attrs.aux_sample_size = sample_size;
         self
     }
 }

--- a/perf-event/src/builder.rs
+++ b/perf-event/src/builder.rs
@@ -158,6 +158,16 @@ impl<'a> Builder<'a> {
 }
 
 impl<'a> Builder<'a> {
+    /// Directly access the [`perf_event_attr`] within this builder.
+    pub fn attrs(&self) -> &perf_event_attr {
+        &self.attrs
+    }
+
+    /// Directly access the [`perf_event_attr`] within this builder.
+    pub fn attrs_mut(&mut self) -> &mut perf_event_attr {
+        &mut self.attrs
+    }
+
     /// Include kernel code.
     pub fn include_kernel(mut self) -> Builder<'a> {
         self.attrs.set_exclude_kernel(0);

--- a/perf-event/src/events.rs
+++ b/perf-event/src/events.rs
@@ -335,6 +335,7 @@ pub enum CacheResult {
 
 bitflags! {
     /// Memory access mask for a hardware data breakpoint.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
     pub struct BreakpointAccess : u32 {
         /// Count when we read the memory location.
         const READ = bindings::HW_BREAKPOINT_R;

--- a/perf-event/src/flags.rs
+++ b/perf-event/src/flags.rs
@@ -1,0 +1,171 @@
+use bitflags::bitflags;
+
+use crate::sys::bindings;
+use crate::Builder;
+
+used_in_docs!(Builder);
+
+/// Configuration of how much skid is allowed when gathering samples.
+///
+/// Skid is the number of instructions that occur between an event occuring and
+/// a sample being gathered by the kernel. Less skid is better but there are
+/// hardware limitations around how small the skid can be.
+///
+/// Also see [`Builder::precise_ip`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum SampleSkid {
+    /// There may be an arbitrary number of instructions between the event and
+    /// the recorded instruction pointer.
+    Arbitrary = 0,
+
+    /// There may be a constant number of instructions between the event and
+    /// and the recorded instruction pointer.
+    Constant = 1,
+
+    /// We've requested that there be 0 skid. This does not guarantee that
+    /// samples will actually have 0 skid.
+    RequestZero = 2,
+
+    /// Skid must be 0. If skid is 0 then the generated sample records will
+    /// have the `PERF_RECORD_MISC_EXACT_IP` bit set.
+    RequireZero = 3,
+}
+
+/// Supported linux clocks that can be used within a perf_event instance.
+///
+/// See the [`clock_gettime(2)`][0] manpage for the full documentation on what
+/// each clock value actually means.
+///
+/// [0]: https://www.mankier.com/2/clock_gettime
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[repr(transparent)]
+pub struct Clock(libc::clockid_t);
+
+impl Clock {
+    /// A clock following International Atomic Time.
+    pub const TAI: Self = Self::new(libc::CLOCK_TAI);
+
+    /// A clock that measures wall-clock time.
+    pub const REALTIME: Self = Self::new(libc::CLOCK_REALTIME);
+
+    /// A clock that is identical to `MONOTONIC` except it also includes any
+    /// time during which the systems was suspended.
+    pub const BOOTTIME: Self = Self::new(libc::CLOCK_BOOTTIME);
+
+    /// A clock that (roughly) corresponds to the time that the system has been
+    /// running since it was booted. (On Linux, at least).
+    pub const MONOTONIC: Self = Self::new(libc::CLOCK_MONOTONIC);
+
+    /// Similar to `MONOTONIC` but does not include NTP adjustments.
+    pub const MONOTONIC_RAW: Self = Self::new(libc::CLOCK_MONOTONIC_RAW);
+}
+
+impl Clock {
+    /// Construct a new `Clock` from the libc clockid value.
+    pub const fn new(clockid: libc::clockid_t) -> Self {
+        Self(clockid)
+    }
+
+    /// Extract the libc clockid value.
+    pub const fn into_raw(self) -> libc::clockid_t {
+        self.0
+    }
+}
+
+bitflags! {
+    /// Specify what branches to include in a branch record.
+    ///
+    /// This is used by the builder in combination with setting
+    /// [`SampleFlag::BRANCH_STACK`].
+    ///
+    /// The first part of the value is the privilege level, which is a
+    /// combination of `USER`, `BRANCH`, or `HV`. `PLM_ALL` is a convenience
+    /// value with all 3 ORed together. If none of the privilege levels are set
+    /// then the kernel will use the privilege level of the event.
+    ///
+    /// The second part specifies which branch types are to be included in the
+    /// branch stack. At least one of these bits must be set.
+    pub struct SampleBranchFlag: u64 {
+        /// The branch target is in user space.
+        const USER = bindings::PERF_SAMPLE_BRANCH_USER as _;
+
+        /// The branch target is in kernel space.
+        const KERNEL = bindings::PERF_SAMPLE_BRANCH_KERNEL as _;
+
+        /// The branch target is in the hypervisor.
+        const HV = bindings::PERF_SAMPLE_BRANCH_HV as _;
+
+        /// Include any branch type.
+        const ANY = bindings::PERF_SAMPLE_BRANCH_ANY as _;
+
+        /// Include any call branch.
+        ///
+        /// This includes direct calls, indirect calls, and far jumps.
+        const ANY_CALL = bindings::PERF_SAMPLE_BRANCH_ANY_CALL as _;
+
+        /// Include indirect calls.
+        const IND_CALL = bindings::PERF_SAMPLE_BRANCH_IND_CALL as _;
+
+        /// Include direct calls.
+        const CALL = bindings::PERF_SAMPLE_BRANCH_CALL as _;
+
+        /// Include any return branch.
+        const ANY_RETURN = bindings::PERF_SAMPLE_BRANCH_ANY_RETURN as _;
+
+        /// Include indirect jumps.
+        const IND_JUMP = bindings::PERF_SAMPLE_BRANCH_IND_JUMP as _;
+
+        /// Include conditional branches.
+        const COND = bindings::PERF_SAMPLE_BRANCH_COND as _;
+
+        /// Include transactional memory aborts.
+        const ABORT_TX = bindings::PERF_SAMPLE_BRANCH_ABORT_TX as _;
+
+        /// Include branches in a transactional memory transaction.
+        const IN_TX = bindings::PERF_SAMPLE_BRANCH_IN_TX as _;
+
+        /// Include branches not in a transactional memory transaction.
+        const NO_TX = bindings::PERF_SAMPLE_BRANCH_NO_TX as _;
+
+        /// Include branches that are part of a hardware-generated call stack.
+        ///
+        /// Note that this requires hardware support. See the [manpage][0] for
+        /// platforms which support this.
+        ///
+        /// [0]: https://www.mankier.com/2/perf_event_open
+        const CALL_STACK = bindings::PERF_SAMPLE_BRANCH_CALL_STACK as _;
+    }
+}
+
+impl SampleBranchFlag {
+    /// All privilege levels (`USER`, `KERNEL`, and `HV`) ORed together.
+    pub const PLM_ALL: Self = Self::USER.union(Self::KERNEL).union(Self::HV);
+}
+
+bitflags! {
+    /// Flags that control what data is returned when reading from a
+    /// perf_event file descriptor.
+    ///
+    /// See the [man page][0] for the authoritative documentation on what
+    /// these flags do.
+    ///
+    /// [0]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+    pub struct ReadFormat : u64 {
+        /// Emit the total amount of time the counter has spent enabled.
+        const TOTAL_TIME_ENABLED = bindings::PERF_FORMAT_TOTAL_TIME_ENABLED as _;
+
+        /// Emit the total amount of time the counter was actually on the
+        /// CPU.
+        const TOTAL_TIME_RUNNING = bindings::PERF_FORMAT_TOTAL_TIME_RUNNING as _;
+
+        /// Emit the counter ID.
+        const ID = bindings::PERF_FORMAT_ID as _;
+
+        /// If in a group, read all the counters in the group at once.
+        const GROUP = bindings::PERF_FORMAT_GROUP as _;
+
+        /// Emit the number of lost samples for this event.
+        const LOST = bindings::PERF_FORMAT_LOST as _;
+    }
+}

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -72,6 +72,21 @@
 
 #![deny(missing_docs)]
 
+/// A helper macro for silencing warnings when a type is only implemented so
+/// that it can be linked in the docs.
+macro_rules! used_in_docs {
+    ($t:ident) => {
+        const _: () = {
+            // Using a module here means that this macro can accept any identifier that
+            // would normally be used in an import statement.
+            mod use_item {
+                #[allow(unused_imports)]
+                use super::$t;
+            }
+        };
+    };
+}
+
 use perf_event_open_sys::bindings::perf_event_attr;
 use std::fs::File;
 use std::io::{self, Read};
@@ -85,6 +100,7 @@ pub mod hooks;
 
 mod builder;
 mod counter;
+mod flags;
 
 // When the `"hooks"` feature is not enabled, call directly into
 // `perf-event-open-sys`.
@@ -98,6 +114,7 @@ use hooks::sys;
 
 pub use crate::builder::Builder;
 pub use crate::counter::Counter;
+pub use crate::flags::{Clock, ReadFormat, SampleBranchFlag, SampleSkid};
 
 /// A group of counters that can be managed as a unit.
 ///


### PR DESCRIPTION
This is a straight upstream of most of the builder methods from `perf-event2`. Many of these allow setting options that are not yet possible to actually use via the crate API (most of the options related to sampling). However, adding `Sampler` is on my future list of things to do so this should generally not be an issue for now.

This partly addresses #29. Another PR will sort out the CLOEXEC bit.