### PR TITLE
`perf-event-open-sys` v6.0.0

### DIFF
--- a/perf-event-open-sys/Cargo.toml
+++ b/perf-event-open-sys/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "perf-event-open-sys"
-version = "5.0.0"
+version = "6.0.0"
 description = """
 Unsafe, direct bindings for Linux's perf_event_open system call, with associated
 types and constants.
 """
 license = "MIT OR Apache-2.0"
-authors = ["Jim Blandy <jimb@red-bean.com>"]
+authors = ["Jim Blandy <jimb@red-bean.com>", "Sean Lynch <sean@lynches.ca>"]
 repository = "https://github.com/jimblandy/perf-event.git"
 edition = "2018"
 readme = "README.md"

--- a/perf-event-open-sys/RELEASE-NOTES.md
+++ b/perf-event-open-sys/RELEASE-NOTES.md
@@ -2,10 +2,17 @@
 
 ## Unreleased
 
+## 6.0.0
+
 -   All bindings have been regenerated from the headers for Linux v6.13.9.
 
 -   The bindings no longer include a large number of types and constants that
     are not related to `perf_event_open`.
+
+-   Added support for 64-bit PowerPC (`powerpc64`).
+
+-   Fields in unnamed unions within `perf_event_attr` can now be directly
+    accessed like they would be in C.
 
 ## 5.0.0
 

--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -26,4 +26,4 @@ libc = "0.2"
 
 [dependencies.perf-event-open-sys]
 path = "../perf-event-open-sys"
-version = "5.0"
+version = "6.0"


### PR DESCRIPTION
I think we have enough changes here that it is time to make a new `perf-event-open-sys` release. I'm not quite ready to do a paired `perf-event` release, so this will have to be standalone at the moment.

@jimblandy I don't have permissions to publish `perf-event-open-sys` to crates.io so you'll either have to do the publish yourself or give me access. It doesn't really matter to me which one you want to go with as long as things get published :)

Anyway, here's the changelog:
#### Changelog

-   All bindings have been regenerated from the headers for Linux v6.13.9.
-   The bindings no longer include a large number of types and constants that are not related to `perf_event_open`.
-   Added support for 64-bit PowerPC (`powerpc64`).
-   Fields in unnamed unions within `perf_event_attr` can now be directly accessed like they would be in C.
