### PR TITLE
Added Raw event tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 **/*.profdata
 **/*.profraw
+*.swp

--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event"
-version = "0.4.8"
+version = "0.4.9"
 description = "A Rust interface to Linux performance monitoring"
 license = "MIT OR Apache-2.0"
 authors = ["Jim Blandy <jimb@red-bean.com>"]


### PR DESCRIPTION
I've added a few things to make the library detect additional events at runtime from sysfs. Something to note is that I wasn't sure how to deal with `config1`, `config2` and `config3` values, so I've left that open to critiques from people who know this crate and perf better than I do.
I've tested this on one ARM system and two x86_64 systems as well, and they seem to work fine; the only event I've tried that doesn't seem to work is cache-misses on one of the x86_64 machines, which I suspect is due to the `config`s not being accounted for, and there are likely others. Again, this is open to critiques.