### PR TITLE
Fix confusing lifetime elision warning in `Counts::iter`

### DIFF
--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -579,8 +579,8 @@ impl Counts {
     /// Each item is a pair `(id, &value)`, where `id` is the number assigned to
     /// the counter by the kernel (see `Counter::id`), and `value` is that
     /// counter's value.
-    pub fn iter(&self) -> CountsIter {
-        <&Counts as IntoIterator>::into_iter(self)
+    pub fn iter<'a>(&'a self) -> CountsIter<'a> {
+        <&'a Counts as IntoIterator>::into_iter(self)
     }
 }
 


### PR DESCRIPTION
This PR addresses a compiler warning in `perf-event/src/lib.rs`:
> warning: hiding a lifetime that's elided elsewhere is confusing: the lifetime is elided here
By explicitly specifying the lifetime in the `Counts::iter` method, the warning is resolved and the intent becomes clearer to both the compiler and readers.
This change should have no functional impact and is purely for code clarity and compatibility with newer Rust toolchains.
No other logic is modified.